### PR TITLE
[feedback] user-friendly feedbacks management

### DIFF
--- a/src/main/java/com/senderman/lastkatkabot/callback/Callbacks.java
+++ b/src/main/java/com/senderman/lastkatkabot/callback/Callbacks.java
@@ -7,4 +7,5 @@ public class Callbacks {
     public final static String DUEL = "DUEL";
     public final static String DIVORCE = "DIVORCE";
     public final static String GREETING = "GREETING";
+    public final static String FEEDBACK_DELETE = "FDEL";
 }

--- a/src/main/java/com/senderman/lastkatkabot/callback/FeedbackDeleteCallback.java
+++ b/src/main/java/com/senderman/lastkatkabot/callback/FeedbackDeleteCallback.java
@@ -1,0 +1,92 @@
+package com.senderman.lastkatkabot.callback;
+
+import com.annimon.tgbotsmodule.api.methods.Methods;
+import com.annimon.tgbotsmodule.commands.context.CallbackQueryContext;
+import com.senderman.lastkatkabot.Role;
+import com.senderman.lastkatkabot.config.BotConfig;
+import com.senderman.lastkatkabot.dbservice.FeedbackService;
+import com.senderman.lastkatkabot.util.Html;
+import jakarta.inject.Singleton;
+import org.jetbrains.annotations.NotNull;
+import org.telegram.telegrambots.meta.api.objects.Message;
+
+import java.util.EnumSet;
+import java.util.Optional;
+
+@Singleton
+public class FeedbackDeleteCallback implements CallbackExecutor {
+
+    private final FeedbackService feedbackRepo;
+    private final BotConfig config;
+
+    public FeedbackDeleteCallback(
+            FeedbackService feedbackRepo,
+            BotConfig config
+    ) {
+        this.feedbackRepo = feedbackRepo;
+        this.config = config;
+    }
+
+    @Override
+    public String command() {
+        return Callbacks.FEEDBACK_DELETE;
+    }
+
+    @Override
+    public EnumSet<Role> authority() {
+        return EnumSet.of(Role.ADMIN, Role.MAIN_ADMIN);
+    }
+
+    @Override
+    public void accept(@NotNull CallbackQueryContext ctx) {
+        if (ctx.argumentsLength() < 1) return;
+
+        var arg = ctx.argument(0);
+        if (arg.equals("close")) {
+            editSourceMessage(ctx, "");
+            return;
+        }
+        if (!arg.matches("\\d+")) return;
+
+        int feedbackId = Integer.parseInt(arg);
+        if (feedbackRepo.existsById(feedbackId)) {
+            feedbackRepo.deleteById(feedbackId);
+            notifySuccess(ctx, "✅ Фидбек #" + feedbackId + " удален");
+        } else {
+            notifyNoFeedbacksFound(ctx);
+        }
+    }
+
+    private void notifySuccess(CallbackQueryContext ctx, String text) {
+        ctx.answerAsAlert(text).callAsync(ctx.sender);
+        editSourceMessage(ctx, text);
+
+        final var msg = getMessage(ctx);
+        if (msg.isEmpty()) return;
+        if (!msg.orElseThrow().getChatId().equals(config.feedbackChannelId()))
+            Methods.sendMessage()
+                    .setChatId(config.feedbackChannelId())
+                    .setText(text + " пользователем " + Html.getUserLink(ctx.user()))
+                    .callAsync(ctx.sender);
+    }
+
+    private void notifyNoFeedbacksFound(CallbackQueryContext ctx) {
+        editSourceMessage(ctx, "ℹ️ Ни одного фидбека не найдено");
+    }
+
+    private static void editSourceMessage(CallbackQueryContext ctx, String text) {
+        getMessage(ctx).ifPresent(msg ->
+                ctx.editMessage(msg.getText() + "\n" + text)
+                        .setChatId(msg.getChatId())
+                        .setMessageId(msg.getMessageId())
+                        .callAsync(ctx.sender));
+    }
+
+    private static Optional<Message> getMessage(CallbackQueryContext ctx) {
+        final var msg = ctx.message();
+        if (msg == null || msg.getChatId() == null || msg.getMessageId() == null) {
+            return Optional.empty();
+        }
+        return Optional.of(msg);
+    }
+}

--- a/src/main/java/com/senderman/lastkatkabot/command/admin/AnswerFeedbackCommand.java
+++ b/src/main/java/com/senderman/lastkatkabot/command/admin/AnswerFeedbackCommand.java
@@ -4,9 +4,11 @@ import com.annimon.tgbotsmodule.api.methods.Methods;
 import com.annimon.tgbotsmodule.commands.context.MessageContext;
 import com.senderman.lastkatkabot.Role;
 import com.senderman.lastkatkabot.annotation.Command;
+import com.senderman.lastkatkabot.callback.Callbacks;
 import com.senderman.lastkatkabot.command.CommandExecutor;
 import com.senderman.lastkatkabot.config.BotConfig;
 import com.senderman.lastkatkabot.dbservice.FeedbackService;
+import com.senderman.lastkatkabot.util.callback.ButtonBuilder;
 import jakarta.inject.Singleton;
 
 import java.util.EnumSet;
@@ -74,7 +76,19 @@ public class AnswerFeedbackCommand implements CommandExecutor {
                 .setText("\uD83D\uDD14 <b>Ответ разработчика</b>\n\n" + answer)
                 .setReplyToMessageId(feedback.getMessageId())
                 .callAsync(ctx.sender);
-        ctx.replyToMessage("Ответ отправлен!").callAsync(ctx.sender);
+
+        ctx.replyToMessage("✅ Ответ отправлен!")
+                .setSingleColumnInlineKeyboard(
+                        ButtonBuilder.callbackButton()
+                                .text("Удалить фидбек")
+                                .payload(Callbacks.FEEDBACK_DELETE + " " + feedback.getId())
+                                .create(),
+                        ButtonBuilder.callbackButton()
+                                .text("Закрыть")
+                                .payload(Callbacks.FEEDBACK_DELETE + " close")
+                                .create()
+                )
+                .callAsync(ctx.sender);
 
         // notify others about answer
         if (!ctx.chatId().equals(config.feedbackChannelId())) {

--- a/src/main/java/com/senderman/lastkatkabot/service/FeedbackFormatterService.java
+++ b/src/main/java/com/senderman/lastkatkabot/service/FeedbackFormatterService.java
@@ -1,0 +1,42 @@
+package com.senderman.lastkatkabot.service;
+
+import com.senderman.lastkatkabot.model.Feedback;
+import com.senderman.lastkatkabot.util.Html;
+import jakarta.inject.Singleton;
+
+@Singleton
+public class FeedbackFormatterService {
+
+    public String format(Feedback feedback) {
+        return """
+                <code>#%d</code>
+                От %s (id<code>%d</code>)%s
+                Отвечен: %s
+
+                %s"""
+                .formatted(
+                        feedback.getId(),
+                        Html.getUserLink(feedback.getUserId(), feedback.getUserName()),
+                        feedback.getUserId(),
+                        formatChatLine(feedback),
+                        formatRepliedLine(feedback),
+                        feedback.getMessage()
+                );
+    }
+
+    private String formatChatLine(Feedback feedback) {
+        if (feedback.getUserId() != feedback.getChatId()) {
+            return " из чата <code>%d</code>".formatted(feedback.getChatId());
+        }
+        return "";
+    }
+
+    private String formatRepliedLine(Feedback feedback) {
+        final int id = feedback.getId();
+        if (feedback.isReplied()) {
+            return "✅ (удалить — <code>/fdel %d</code>)".formatted(id);
+        } else {
+            return "❌ (<code>/fresp %d </code>ваш ответ)".formatted(id);
+        }
+    }
+}

--- a/src/main/java/com/senderman/lastkatkabot/util/Html.java
+++ b/src/main/java/com/senderman/lastkatkabot/util/Html.java
@@ -5,7 +5,11 @@ import org.telegram.telegrambots.meta.api.objects.User;
 public class Html {
 
     public static String getUserLink(User user) {
-        return "<a href=\"tg://user?id=" + user.getId() + "\">" + htmlSafe(user.getFirstName()) + "</a>";
+        return getUserLink(user.getId(), user.getFirstName());
+    }
+
+    public static String getUserLink(Long id, String name) {
+        return "<a href=\"tg://user?id=" + id + "\">" + htmlSafe(name) + "</a>";
     }
 
     public static String htmlSafe(String s) {


### PR DESCRIPTION
 - Added inline buttons to quickly delete feedback after answering
 - Unified feedback rendering (1 - after receiving a feedback, 2 - in /feedbacks command output) by introducing `FeedbackFormatterService`
 - In /feedbacks output added notes for quickly copying a command for answering feedback if it's not answered yet, or deleting feedback if it was answered, but still not deleted. 